### PR TITLE
Fixed inconsistent use of ToLowerInvariant

### DIFF
--- a/Sorting/ItemSorter.cs
+++ b/Sorting/ItemSorter.cs
@@ -138,7 +138,7 @@ namespace MagicStorage.Sorting
 			{
 				modName = item.modItem.mod.DisplayName;
 			}
-			return modName.ToLowerInvariant().IndexOf(modFilter) >= 0 && item.Name.ToLowerInvariant().IndexOf(filter.ToLowerInvariant()) >= 0;
+			return modName.ToLowerInvariant().IndexOf(modFilter.ToLowerInvariant()) >= 0 && item.Name.ToLowerInvariant().IndexOf(filter.ToLowerInvariant()) >= 0;
 		}
 	}
 }


### PR DESCRIPTION
Inconsistent use of String.ToLowerInvariant() in the return line of FilterName(string, string, string) has been forcing players to enter filter criteria in all lower case characters. By adding a call to ToLowerInvariant() on modFilter, the player may now search with any casing.


(From mixels)